### PR TITLE
Kconfig: Name CPP STD choice symbol

### DIFF
--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -10,7 +10,7 @@ menuconfig CPLUSPLUS
 
 if CPLUSPLUS
 
-choice
+choice STD_CPP
 	prompt "C++ Standard"
 	default STD_CPP11
 	help


### PR DESCRIPTION
Anonymous choices can't be overriden in Kconfig files.