### PR TITLE
Revert "Boards: Add aliases to atsamd21_xpro"

### DIFF
--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -19,7 +19,7 @@
 	};
 
 	/* These aliases are provided for compatibility with samples */
-	aliases: aliases {
+	aliases {
 		led0 = &led0;
 		pwm-led0 = &pwm_led0;
 		sw0 = &user_button;


### PR DESCRIPTION
Reverts zonneplan/sdk-zephyr#5

We don't need this sicce we can just do
```
/ {
    aliases {
    };
};
```