### PR TITLE
adc: add pinctrl support to adc sam0 driver

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -56,6 +56,8 @@ struct adc_sam0_cfg {
 	uint16_t prescaler;
 
 	void (*config_func)(const struct device *dev);
+	uint32_t num_pins;
+	struct soc_port_pin pins[];
 };
 
 #define DEV_CFG(dev) \
@@ -460,6 +462,11 @@ static int adc_sam0_init(const struct device *dev)
 	struct adc_sam0_data *data = DEV_DATA(dev);
 	Adc *const adc = cfg->regs;
 
+	/* Set adc pins to correct mux */
+	for (size_t i=0;i<cfg->num_pins;i++) {
+		soc_port_configure(&cfg->pins[i]);
+	}
+
 #ifdef MCLK
 	GCLK->PCHCTRL[cfg->gclk_id].reg = cfg->gclk_mask | GCLK_PCHCTRL_CHEN;
 
@@ -596,6 +603,8 @@ do {									\
 					  _FREQ_HZ) /			\
 			DT_INST_PROP(n, prescaler),			\
 		.config_func = &adc_sam0_config_##n,			\
+		.num_pins = ATMEL_SAM0_DT_INST_NUM_PINS(n),		\
+		.pins = ATMEL_SAM0_DT_INST_PINS(n),			\
 	};								\
 	static struct adc_sam0_data adc_sam_data_##n = {		\
 		ADC_CONTEXT_INIT_TIMER(adc_sam_data_##n, ctx),		\

--- a/dts/arm/atmel/samd2x-pinctrl.dtsi
+++ b/dts/arm/atmel/samd2x-pinctrl.dtsi
@@ -72,6 +72,27 @@
 			DT_ATMEL_PORT(sercom5, pad3, b,  1, d, pinmux-enable);
 			DT_ATMEL_PORT(sercom5, pad0, b,  2, d, pinmux-enable);
 			DT_ATMEL_PORT(sercom5, pad1, b,  3, d, pinmux-enable);
+
+			DT_ATMEL_PORT(adc,  chan0, a,   2, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan1, a,   3, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan2, b,   8, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan3, b,   9, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan4, a,   4, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan5, a,   5, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan6, a,   6, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan7, a,   7, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan8, b,   0, b, pinmux-enable);
+			DT_ATMEL_PORT(adc,  chan9, b,   1, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan10, b,   2, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan11, b,   3, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan12, b,   4, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan13, b,   5, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan14, b,   6, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan15, b,   7, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan16, a,   8, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan17, a,   9, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan18, a,  10, b, pinmux-enable);
+			DT_ATMEL_PORT(adc, chan19, a,  11, b, pinmux-enable);
 		};
 	};
 };

--- a/dts/bindings/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/adc/atmel,sam0-adc.yaml
@@ -49,9 +49,9 @@ properties:
         PIO pin configuration for adc pin and channel.  We expect that
         the phandles will reference pinctrl nodes.  These nodes will
         have a nodelabel that matches the Atmel SoC HAL defines and
-        be of the form p<port><pin><periph>_<chan>_<signal>.
+        be of the form p<port><pin><periph>_<inst>_<chan>.
 
-        For example the I2C0 on SAMD21 would be
+        For example the ADC on SAMD21 would be
            pinctrl-0 = <&pa9d_adc_chan19>;
 
       required: true

--- a/dts/bindings/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/adc/atmel,sam0-adc.yaml
@@ -43,6 +43,18 @@ properties:
       enum:
         - 0
         - 14
+    pinctrl-0:
+      type: phandles
+      description: |
+        PIO pin configuration for adc pin and channel.  We expect that
+        the phandles will reference pinctrl nodes.  These nodes will
+        have a nodelabel that matches the Atmel SoC HAL defines and
+        be of the form p<port><pin><periph>_<chan>_<signal>.
+
+        For example the I2C0 on SAMD21 would be
+           pinctrl-0 = <&pa9d_adc_chan19>;
+
+      required: true
 
 io-channel-cells:
     - input


### PR DESCRIPTION
Update the sam0 adc driver with pinctrl support

Signed-off-by: Erik Kallen <info@erikkallen.nl>