### PR TITLE
adc: count number of bits in channel sam0 adc driver

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -335,6 +335,15 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 	return 0;
 }
 
+static int _count_set_bits(unsigned int n) {
+	// Count the total bits set in n
+	uint8_t count = 0;
+	for (count = 0; n; n >>= 1) {
+		count += n & 1;
+	}
+	return count;
+}
+
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
 {
@@ -394,7 +403,7 @@ static int start_read(const struct device *dev,
 
 	wait_synchronization(adc);
 
-	if (sequence->channels != 1U) {
+	if (_count_set_bits(sequence->channels) != 1U) {
 		LOG_ERR("Channel scanning is not supported");
 		return -ENOTSUP;
 	}

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -335,15 +335,6 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 	return 0;
 }
 
-static int _count_set_bits(unsigned int n) {
-	// Count the total bits set in n
-	uint8_t count = 0;
-	for (count = 0; n; n >>= 1) {
-		count += n & 1;
-	}
-	return count;
-}
-
 static int start_read(const struct device *dev,
 		      const struct adc_sequence *sequence)
 {
@@ -403,7 +394,7 @@ static int start_read(const struct device *dev,
 
 	wait_synchronization(adc);
 
-	if (_count_set_bits(sequence->channels) != 1U) {
+	if (!is_power_of_two(sequence->channels)) {
 		LOG_ERR("Channel scanning is not supported");
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
sam0 driver can only handle 1 channel, but the number of channels where not counted correctly so the check failed on channels > 0

Signed-off-by: Erik Kallen <info@erikkallen.nl>