### PR TITLE
* bugfix: pwm: PER register and CC register are not updated correctly…

### DIFF
--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -86,14 +86,13 @@ static int pwm_sam0_pin_set(const struct device *dev, uint32_t ch,
 	regs->PERBUF.reg = TCC_PERBUF_PERBUF(period_cycles);
 #else
 	/* SAMD21 naming */
-	regs->CCB[ch].reg = TCC_CCB_CCB(pulse_cycles);
-	regs->PERB.reg = TCC_PERB_PERB(period_cycles);
+	regs->CC[ch].reg = TCC_CCB_CCB(pulse_cycles);
+	regs->PER.reg = TCC_PERB_PERB(period_cycles);
 #endif
 
 	if (invert != inverted) {
 		regs->CTRLA.bit.ENABLE = 0;
 		wait_synchronization(regs);
-
 		regs->DRVCTRL.vec.INVEN ^= invert_mask;
 		regs->CTRLA.bit.ENABLE = 1;
 		wait_synchronization(regs);

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -93,6 +93,7 @@ static int pwm_sam0_pin_set(const struct device *dev, uint32_t ch,
 	if (invert != inverted) {
 		regs->CTRLA.bit.ENABLE = 0;
 		wait_synchronization(regs);
+
 		regs->DRVCTRL.vec.INVEN ^= invert_mask;
 		regs->CTRLA.bit.ENABLE = 1;
 		wait_synchronization(regs);


### PR DESCRIPTION
… when using the buffered versions PERB and CCB

As a workaround we write to the CC en PER registers directly

Signed-off-by: Erik Kallen <info@erikkallen.nl>