### PR TITLE
Modbus: During tx some line drivers have interference on the rx line …

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -421,13 +421,10 @@ static void uart_cb_handler(const struct device *dev, void *app_data)
 	cfg = ctx->cfg;
 
 	while (uart_irq_update(cfg->dev) && uart_irq_is_pending(cfg->dev)) {
-
-		if (uart_irq_rx_ready(cfg->dev)) {
-			cb_handler_rx(ctx);
-		}
-
 		if (uart_irq_tx_ready(cfg->dev)) {
 			cb_handler_tx(ctx);
+		} else if (uart_irq_rx_ready(cfg->dev)) {
+			cb_handler_rx(ctx);
 		}
 	}
 }


### PR DESCRIPTION
…this causes the rx callback to be triggered which will then corrupt the tx buffer since it is shared between rx and tx
Since there is only ever supposed to be a send or receive interrupt at once we can make them exclusive.

Signed-off-by: Erik Kallen <info@erikkallen.nl>