### PR TITLE
modbus: Move modbus context out of library

### DIFF
--- a/include/modbus/modbus.h
+++ b/include/modbus/modbus.h
@@ -41,6 +41,9 @@ extern "C" {
 /** Length of MBAP Header plus function code */
 #define MODBUS_MBAP_AND_FC_LENGTH	(MODBUS_MBAP_LENGTH + 1)
 
+// Forward declare
+struct modbus_context;
+
 /**
  * @brief Frame struct used internally and for raw ADU support.
  */
@@ -62,317 +65,6 @@ struct modbus_adu {
 };
 
 /**
- * @brief Coil read (FC01)
- *
- * Sends a Modbus message to read the status of coils from a server.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Coil starting address
- * @param coil_tbl   Pointer to an array of bytes containing the value
- *                   of the coils read.
- *                   The format is:
- *
- *                                       MSB                               LSB
- *                                       B7   B6   B5   B4   B3   B2   B1   B0
- *                                       -------------------------------------
- *                       coil_tbl[0]     #8   #7                            #1
- *                       coil_tbl[1]     #16  #15                           #9
- *                            :
- *                            :
- *
- *                   Note that the array that will be receiving the coil
- *                   values must be greater than or equal to:
- *                   (num_coils - 1) / 8 + 1
- * @param num_coils  Quantity of coils to read
- *
- * @retval           0 If the function was successful
- */
-int modbus_read_coils(const int iface,
-		      const uint8_t unit_id,
-		      const uint16_t start_addr,
-		      uint8_t *const coil_tbl,
-		      const uint16_t num_coils);
-
-/**
- * @brief Read discrete inputs (FC02)
- *
- * Sends a Modbus message to read the status of discrete inputs from
- * a server.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Discrete input starting address
- * @param di_tbl     Pointer to an array that will receive the state
- *                   of the discrete inputs.
- *                   The format of the array is as follows:
- *
- *                                     MSB                               LSB
- *                                     B7   B6   B5   B4   B3   B2   B1   B0
- *                                     -------------------------------------
- *                       di_tbl[0]     #8   #7                            #1
- *                       di_tbl[1]     #16  #15                           #9
- *                            :
- *                            :
- *
- *                   Note that the array that will be receiving the discrete
- *                   input values must be greater than or equal to:
- *                        (num_di - 1) / 8 + 1
- * @param num_di     Quantity of discrete inputs to read
- *
- * @retval           0 If the function was successful
- */
-int modbus_read_dinputs(const int iface,
-			const uint8_t unit_id,
-			const uint16_t start_addr,
-			uint8_t *const di_tbl,
-			const uint16_t num_di);
-
-/**
- * @brief Read holding registers (FC03)
- *
- * Sends a Modbus message to read the value of holding registers
- * from a server.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Register starting address
- * @param reg_buf    Is a pointer to an array that will receive
- *                   the current values of the holding registers from
- *                   the server.  The array pointed to by 'reg_buf' needs
- *                   to be able to hold at least 'num_regs' entries.
- * @param num_regs   Quantity of registers to read
- *
- * @retval           0 If the function was successful
- */
-int modbus_read_holding_regs(const int iface,
-			     const uint8_t unit_id,
-			     const uint16_t start_addr,
-			     uint16_t *const reg_buf,
-			     const uint16_t num_regs);
-
-/**
- * @brief Read input registers (FC04)
- *
- * Sends a Modbus message to read the value of input registers from
- * a server.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Register starting address
- * @param reg_buf    Is a pointer to an array that will receive
- *                   the current value of the holding registers
- *                   from the server.  The array pointed to by 'reg_buf'
- *                   needs to be able to hold at least 'num_regs' entries.
- * @param num_regs   Quantity of registers to read
- *
- * @retval           0 If the function was successful
- */
-int modbus_read_input_regs(const int iface,
-			   const uint8_t unit_id,
-			   const uint16_t start_addr,
-			   uint16_t *const reg_buf,
-			   const uint16_t num_regs);
-
-/**
- * @brief Write single coil (FC05)
- *
- * Sends a Modbus message to write the value of single coil to a server.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param coil_addr  Coils starting address
- * @param coil_state Is the desired state of the coil
- *
- * @retval           0 If the function was successful
- */
-int modbus_write_coil(const int iface,
-		      const uint8_t unit_id,
-		      const uint16_t coil_addr,
-		      const bool coil_state);
-
-/**
- * @brief Write single holding register (FC06)
- *
- * Sends a Modbus message to write the value of single holding register
- * to a server unit.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Coils starting address
- * @param reg_val    Desired value of the holding register
- *
- * @retval           0 If the function was successful
- */
-int modbus_write_holding_reg(const int iface,
-			     const uint8_t unit_id,
-			     const uint16_t start_addr,
-			     const uint16_t reg_val);
-
-/**
- * @brief Read diagnostic (FC08)
- *
- * Sends a Modbus message to perform a diagnostic function of a server unit.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param sfunc      Diagnostic sub-function code
- * @param data       Sub-function data
- * @param data_out   Pointer to the data value
- *
- * @retval           0 If the function was successful
- */
-int modbus_request_diagnostic(const int iface,
-			      const uint8_t unit_id,
-			      const uint16_t sfunc,
-			      const uint16_t data,
-			      uint16_t *const data_out);
-
-/**
- * @brief Write coils (FC15)
- *
- * Sends a Modbus message to write to coils on a server unit.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Coils starting address
- * @param coil_tbl   Pointer to an array of bytes containing the value
- *                   of the coils to write.
- *                   The format is:
- *
- *                                       MSB                               LSB
- *                                       B7   B6   B5   B4   B3   B2   B1   B0
- *                                       -------------------------------------
- *                       coil_tbl[0]     #8   #7                            #1
- *                       coil_tbl[1]     #16  #15                           #9
- *                            :
- *                            :
- *
- *                   Note that the array that will be receiving the coil
- *                   values must be greater than or equal to:
- *                   (num_coils - 1) / 8 + 1
- * @param num_coils  Quantity of coils to write
- *
- * @retval           0 If the function was successful
- */
-int modbus_write_coils(const int iface,
-		       const uint8_t unit_id,
-		       const uint16_t start_addr,
-		       uint8_t *const coil_tbl,
-		       const uint16_t num_coils);
-
-/**
- * @brief Write holding registers (FC16)
- *
- * Sends a Modbus message to write to integer holding registers
- * to a server unit.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Register starting address
- * @param reg_buf    Is a pointer to an array containing
- *                   the value of the holding registers to write.
- *                   Note that the array containing the register values must
- *                   be greater than or equal to 'num_regs'
- * @param num_regs   Quantity of registers to write
- *
- * @retval           0 If the function was successful
- */
-int modbus_write_holding_regs(const int iface,
-			      const uint8_t unit_id,
-			      const uint16_t start_addr,
-			      uint16_t *const reg_buf,
-			      const uint16_t num_regs);
-
-/**
- * @brief Read floating-point holding registers (FC03)
- *
- * Sends a Modbus message to read the value of floating-point
- * holding registers from a server unit.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Register starting address
- * @param reg_buf    Is a pointer to an array that will receive
- *                   the current values of the holding registers from
- *                   the server.  The array pointed to by 'reg_buf' needs
- *                   to be able to hold at least 'num_regs' entries.
- * @param num_regs   Quantity of registers to read
- *
- * @retval           0 If the function was successful
- */
-int modbus_read_holding_regs_fp(const int iface,
-				const uint8_t unit_id,
-				const uint16_t start_addr,
-				float *const reg_buf,
-				const uint16_t num_regs);
-
-/**
- * @brief Write floating-point holding registers (FC16)
- *
- * Sends a Modbus message to write to floating-point holding registers
- * to a server unit.
- *
- * @param iface      Modbus interface index
- * @param unit_id    Modbus unit ID of the server
- * @param start_addr Register starting address
- * @param reg_buf    Is a pointer to an array containing
- *                   the value of the holding registers to write.
- *                   Note that the array containing the register values must
- *                   be greater than or equal to 'num_regs'
- * @param num_regs   Quantity of registers to write
- *
- * @retval           0 If the function was successful
- */
-int modbus_write_holding_regs_fp(const int iface,
-				 const uint8_t unit_id,
-				 const uint16_t start_addr,
-				 float *const reg_buf,
-				 const uint16_t num_regs);
-
-/** Modbus Server User Callback structure */
-struct modbus_user_callbacks {
-	/** Coil read callback */
-	int (*coil_rd)(uint16_t addr, bool *state);
-
-	/** Coil write callback */
-	int (*coil_wr)(uint16_t addr, bool state);
-
-	/** Discrete Input read callback */
-	int (*discrete_input_rd)(uint16_t addr, bool *state);
-
-	/** Input Register read callback */
-	int (*input_reg_rd)(uint16_t addr, uint16_t *reg);
-
-	/** Floating Point Input Register read callback */
-	int (*input_reg_rd_fp)(uint16_t addr, float *reg);
-
-	/** Holding Register read callback */
-	int (*holding_reg_rd)(uint16_t addr, uint16_t *reg);
-
-	/** Holding Register write callback */
-	int (*holding_reg_wr)(uint16_t addr, uint16_t reg);
-
-	/** Floating Point Holding Register read callback */
-	int (*holding_reg_rd_fp)(uint16_t addr, float *reg);
-
-	/** Floating Point Holding Register write callback */
-	int (*holding_reg_wr_fp)(uint16_t addr, float reg);
-};
-
-/**
- * @brief Get Modbus interface index according to interface name
- *
- * If there is more than one interface, it can be used to clearly
- * identify interfaces in the application.
- *
- * @param iface_name Modbus interface name
- *
- * @retval           Modbus interface index or negative error value.
- */
-int modbus_iface_get_by_name(const char *iface_name);
-
-/**
  * @brief ADU raw callback function signature
  *
  * @param iface      Modbus RTU interface index
@@ -380,7 +72,28 @@ int modbus_iface_get_by_name(const char *iface_name);
  *
  * @retval           0 If transfer was successful
  */
-typedef int (*modbus_raw_cb_t)(const int iface, const struct modbus_adu *adu);
+typedef int (*modbus_raw_cb_t)(struct modbus_context *ctx, const struct modbus_adu *adu);
+
+struct modbus_serial_config {
+	/* UART device name */
+	const char *dev_name;
+	/* UART device */
+	const struct device *dev;
+	/* RTU timeout (maximum inter-frame delay) */
+	uint32_t rtu_timeout;
+	/* Pointer to current position in buffer */
+	uint8_t *uart_buf_ptr;
+	/* Pointer to driver enable (DE) pin config */
+	struct gpio_dt_spec *de;
+	/* Pointer to receiver enable (nRE) pin config */
+	struct gpio_dt_spec *re;
+	/* RTU timer to detect frame end point */
+	struct k_timer rtu_timer;
+	/* Number of bytes received or to send */
+	uint16_t uart_buf_ctr;
+	/* Storage of received characters or characters to send */
+	uint8_t uart_buf[CONFIG_MODBUS_BUFFER_SIZE];
+};
 
 /**
  * @brief Modbus interface mode
@@ -440,6 +153,324 @@ struct modbus_iface_param {
 	};
 };
 
+struct modbus_context {
+	/* Interface name */
+	const char *iface_name;
+	union {
+		/* Serial line configuration */
+		struct modbus_serial_config *cfg;
+		/* RAW TX callback */
+		modbus_raw_cb_t raw_tx_cb;
+	};
+	/* MODBUS mode */
+	enum modbus_mode mode;
+	/* True if interface is configured as client */
+	bool client;
+	/* Amount of time client is willing to wait for response from server */
+	uint32_t rxwait_to;
+	/* Pointer to user server callbacks */
+	struct modbus_user_callbacks *mbs_user_cb;
+	/* Interface state */
+	atomic_t state;
+
+	/* Client's mutually exclusive access */
+	struct k_mutex iface_lock;
+	/* Wait for response semaphore */
+	struct k_sem client_wait_sem;
+	/* Server work item */
+	struct k_work server_work;
+	/* Received frame */
+	struct modbus_adu rx_adu;
+	/* Frame to transmit */
+	struct modbus_adu tx_adu;
+
+	/* Records error from frame reception, e.g. CRC error */
+	int rx_adu_err;
+
+#ifdef CONFIG_MODBUS_FC08_DIAGNOSTIC
+	uint16_t mbs_msg_ctr;
+	uint16_t mbs_crc_err_ctr;
+	uint16_t mbs_except_ctr;
+	uint16_t mbs_server_msg_ctr;
+	uint16_t mbs_noresp_ctr;
+#endif
+	/* Unit ID */
+	uint8_t unit_id;
+};
+
+/**
+ * @brief Coil read (FC01)
+ *
+ * Sends a Modbus message to read the status of coils from a server.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Coil starting address
+ * @param coil_tbl   Pointer to an array of bytes containing the value
+ *                   of the coils read.
+ *                   The format is:
+ *
+ *                                       MSB                               LSB
+ *                                       B7   B6   B5   B4   B3   B2   B1   B0
+ *                                       -------------------------------------
+ *                       coil_tbl[0]     #8   #7                            #1
+ *                       coil_tbl[1]     #16  #15                           #9
+ *                            :
+ *                            :
+ *
+ *                   Note that the array that will be receiving the coil
+ *                   values must be greater than or equal to:
+ *                   (num_coils - 1) / 8 + 1
+ * @param num_coils  Quantity of coils to read
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_read_coils(struct modbus_context *ctx, const uint8_t unit_id, const uint16_t start_addr,
+		      uint8_t *const coil_tbl, const uint16_t num_coils);
+
+/**
+ * @brief Read discrete inputs (FC02)
+ *
+ * Sends a Modbus message to read the status of discrete inputs from
+ * a server.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Discrete input starting address
+ * @param di_tbl     Pointer to an array that will receive the state
+ *                   of the discrete inputs.
+ *                   The format of the array is as follows:
+ *
+ *                                     MSB                               LSB
+ *                                     B7   B6   B5   B4   B3   B2   B1   B0
+ *                                     -------------------------------------
+ *                       di_tbl[0]     #8   #7                            #1
+ *                       di_tbl[1]     #16  #15                           #9
+ *                            :
+ *                            :
+ *
+ *                   Note that the array that will be receiving the discrete
+ *                   input values must be greater than or equal to:
+ *                        (num_di - 1) / 8 + 1
+ * @param num_di     Quantity of discrete inputs to read
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_read_dinputs(struct modbus_context *ctx, const uint8_t unit_id,
+			const uint16_t start_addr, uint8_t *const di_tbl, const uint16_t num_di);
+
+/**
+ * @brief Read holding registers (FC03)
+ *
+ * Sends a Modbus message to read the value of holding registers
+ * from a server.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Register starting address
+ * @param reg_buf    Is a pointer to an array that will receive
+ *                   the current values of the holding registers from
+ *                   the server.  The array pointed to by 'reg_buf' needs
+ *                   to be able to hold at least 'num_regs' entries.
+ * @param num_regs   Quantity of registers to read
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_read_holding_regs(struct modbus_context *ctx, const uint8_t unit_id,
+			     const uint16_t start_addr, uint16_t *const reg_buf,
+			     const uint16_t num_regs);
+
+/**
+ * @brief Read input registers (FC04)
+ *
+ * Sends a Modbus message to read the value of input registers from
+ * a server.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Register starting address
+ * @param reg_buf    Is a pointer to an array that will receive
+ *                   the current value of the holding registers
+ *                   from the server.  The array pointed to by 'reg_buf'
+ *                   needs to be able to hold at least 'num_regs' entries.
+ * @param num_regs   Quantity of registers to read
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_read_input_regs(struct modbus_context *ctx, const uint8_t unit_id,
+			   const uint16_t start_addr, uint16_t *const reg_buf,
+			   const uint16_t num_regs);
+
+/**
+ * @brief Write single coil (FC05)
+ *
+ * Sends a Modbus message to write the value of single coil to a server.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param coil_addr  Coils starting address
+ * @param coil_state Is the desired state of the coil
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_write_coil(struct modbus_context *ctx, const uint8_t unit_id, const uint16_t coil_addr,
+		      const bool coil_state);
+
+/**
+ * @brief Write single holding register (FC06)
+ *
+ * Sends a Modbus message to write the value of single holding register
+ * to a server unit.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Coils starting address
+ * @param reg_val    Desired value of the holding register
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_write_holding_reg(struct modbus_context *ctx, const uint8_t unit_id,
+			     const uint16_t start_addr, const uint16_t reg_val);
+
+/**
+ * @brief Read diagnostic (FC08)
+ *
+ * Sends a Modbus message to perform a diagnostic function of a server unit.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param sfunc      Diagnostic sub-function code
+ * @param data       Sub-function data
+ * @param data_out   Pointer to the data value
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_request_diagnostic(struct modbus_context *ctx, const uint8_t unit_id,
+			      const uint16_t sfunc, const uint16_t data, uint16_t *const data_out);
+
+/**
+ * @brief Write coils (FC15)
+ *
+ * Sends a Modbus message to write to coils on a server unit.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Coils starting address
+ * @param coil_tbl   Pointer to an array of bytes containing the value
+ *                   of the coils to write.
+ *                   The format is:
+ *
+ *                                       MSB                               LSB
+ *                                       B7   B6   B5   B4   B3   B2   B1   B0
+ *                                       -------------------------------------
+ *                       coil_tbl[0]     #8   #7                            #1
+ *                       coil_tbl[1]     #16  #15                           #9
+ *                            :
+ *                            :
+ *
+ *                   Note that the array that will be receiving the coil
+ *                   values must be greater than or equal to:
+ *                   (num_coils - 1) / 8 + 1
+ * @param num_coils  Quantity of coils to write
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_write_coils(struct modbus_context *ctx, const uint8_t unit_id, const uint16_t start_addr,
+		       uint8_t *const coil_tbl, const uint16_t num_coils);
+
+/**
+ * @brief Write holding registers (FC16)
+ *
+ * Sends a Modbus message to write to integer holding registers
+ * to a server unit.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Register starting address
+ * @param reg_buf    Is a pointer to an array containing
+ *                   the value of the holding registers to write.
+ *                   Note that the array containing the register values must
+ *                   be greater than or equal to 'num_regs'
+ * @param num_regs   Quantity of registers to write
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_write_holding_regs(struct modbus_context *ctx, const uint8_t unit_id,
+			      const uint16_t start_addr, uint16_t *const reg_buf,
+			      const uint16_t num_regs);
+
+/**
+ * @brief Read floating-point holding registers (FC03)
+ *
+ * Sends a Modbus message to read the value of floating-point
+ * holding registers from a server unit.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Register starting address
+ * @param reg_buf    Is a pointer to an array that will receive
+ *                   the current values of the holding registers from
+ *                   the server.  The array pointed to by 'reg_buf' needs
+ *                   to be able to hold at least 'num_regs' entries.
+ * @param num_regs   Quantity of registers to read
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_read_holding_regs_fp(struct modbus_context *ctx, const uint8_t unit_id,
+				const uint16_t start_addr, float *const reg_buf,
+				const uint16_t num_regs);
+
+/**
+ * @brief Write floating-point holding registers (FC16)
+ *
+ * Sends a Modbus message to write to floating-point holding registers
+ * to a server unit.
+ *
+ * @param iface      Modbus interface index
+ * @param unit_id    Modbus unit ID of the server
+ * @param start_addr Register starting address
+ * @param reg_buf    Is a pointer to an array containing
+ *                   the value of the holding registers to write.
+ *                   Note that the array containing the register values must
+ *                   be greater than or equal to 'num_regs'
+ * @param num_regs   Quantity of registers to write
+ *
+ * @retval           0 If the function was successful
+ */
+int modbus_write_holding_regs_fp(struct modbus_context *ctx, const uint8_t unit_id,
+				 const uint16_t start_addr, float *const reg_buf,
+				 const uint16_t num_regs);
+
+/** Modbus Server User Callback structure */
+struct modbus_user_callbacks {
+	/** Coil read callback */
+	int (*coil_rd)(struct modbus_context *ctx, uint16_t addr, bool *state);
+
+	/** Coil write callback */
+	int (*coil_wr)(struct modbus_context *ctx, uint16_t addr, bool state);
+
+	/** Discrete Input read callback */
+	int (*discrete_input_rd)(struct modbus_context *ctx, uint16_t addr, bool *state);
+
+	/** Input Register read callback */
+	int (*input_reg_rd)(struct modbus_context *ctx, uint16_t addr, uint16_t *reg);
+
+	/** Floating Point Input Register read callback */
+	int (*input_reg_rd_fp)(struct modbus_context *ctx, uint16_t addr, float *reg);
+
+	/** Holding Register read callback */
+	int (*holding_reg_rd)(struct modbus_context *ctx, uint16_t addr, uint16_t *reg);
+
+	/** Holding Register write callback */
+	int (*holding_reg_wr)(struct modbus_context *ctx, uint16_t addr, uint16_t reg);
+
+	/** Floating Point Holding Register read callback */
+	int (*holding_reg_rd_fp)(struct modbus_context *ctx, uint16_t addr, float *reg);
+
+	/** Floating Point Holding Register write callback */
+	int (*holding_reg_wr_fp)(struct modbus_context *ctx, uint16_t addr, float reg);
+};
+
 /**
  * @brief Configure Modbus Interface as raw ADU server
  *
@@ -448,7 +479,7 @@ struct modbus_iface_param {
  *
  * @retval           0 If the function was successful
  */
-int modbus_init_server(const int iface, struct modbus_iface_param param);
+int modbus_init_server(struct modbus_context *ctx, struct modbus_iface_param param);
 
 /**
  * @brief Configure Modbus Interface as raw ADU client
@@ -458,7 +489,7 @@ int modbus_init_server(const int iface, struct modbus_iface_param param);
  *
  * @retval           0 If the function was successful
  */
-int modbus_init_client(const int iface, struct modbus_iface_param param);
+int modbus_init_client(struct modbus_context *ctx, struct modbus_iface_param param);
 
 /**
  * @brief Disable Modbus Interface
@@ -469,7 +500,7 @@ int modbus_init_client(const int iface, struct modbus_iface_param param);
  *
  * @retval           0 If the function was successful
  */
-int modbus_disable(const uint8_t iface);
+int modbus_disable(struct modbus_context *ctx);
 
 /**
  * @brief Submit raw ADU
@@ -479,7 +510,7 @@ int modbus_disable(const uint8_t iface);
  *
  * @retval           0 If transfer was successful
  */
-int modbus_raw_submit_rx(const int iface, const struct modbus_adu *adu);
+int modbus_raw_submit_rx(struct modbus_context *ctx, const struct modbus_adu *adu);
 
 /**
  * @brief Put MBAP header into a buffer
@@ -523,7 +554,7 @@ void modbus_raw_set_server_failure(struct modbus_adu *adu);
  *
  * @retval           0 If transfer was successful
  */
-int modbus_raw_backend_txn(const int iface, struct modbus_adu *adu);
+int modbus_raw_backend_txn(struct modbus_context *ctx, struct modbus_adu *adu);
 
 #ifdef __cplusplus
 }

--- a/subsys/modbus/modbus_client.c
+++ b/subsys/modbus/modbus_client.c
@@ -290,13 +290,12 @@ static int mbc_send_cmd(struct modbus_context *ctx, const uint8_t unit_id,
 	return err;
 }
 
-int modbus_read_coils(const int iface,
+int modbus_read_coils(struct modbus_context *ctx,
 		      const uint8_t unit_id,
 		      const uint16_t start_addr,
 		      uint8_t *const coil_tbl,
 		      const uint16_t num_coils)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 
 	if (ctx == NULL) {
@@ -315,13 +314,12 @@ int modbus_read_coils(const int iface,
 	return err;
 }
 
-int modbus_read_dinputs(const int iface,
+int modbus_read_dinputs(struct modbus_context *ctx,
 			const uint8_t unit_id,
 			const uint16_t start_addr,
 			uint8_t *const di_tbl,
 			const uint16_t num_di)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 
 	if (ctx == NULL) {
@@ -340,13 +338,12 @@ int modbus_read_dinputs(const int iface,
 	return err;
 }
 
-int modbus_read_holding_regs(const int iface,
+int modbus_read_holding_regs(struct modbus_context *ctx,
 			     const uint8_t unit_id,
 			     const uint16_t start_addr,
 			     uint16_t *const reg_buf,
 			     const uint16_t num_regs)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 
 	if (ctx == NULL) {
@@ -367,13 +364,12 @@ int modbus_read_holding_regs(const int iface,
 
 
 #ifdef CONFIG_MODBUS_FP_EXTENSIONS
-int modbus_read_holding_regs_fp(const int iface,
+int modbus_read_holding_regs_fp(struct modbus_context *ctx,
 			       const uint8_t unit_id,
 			       const uint16_t start_addr,
 			       float *const reg_buf,
 			       const uint16_t num_regs)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 
 	if (ctx == NULL) {
@@ -393,13 +389,12 @@ int modbus_read_holding_regs_fp(const int iface,
 }
 #endif
 
-int modbus_read_input_regs(const int iface,
+int modbus_read_input_regs(struct modbus_context *ctx,
 			   const uint8_t unit_id,
 			   const uint16_t start_addr,
 			   uint16_t *const reg_buf,
 			   const uint16_t num_regs)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 
 	if (ctx == NULL) {
@@ -418,12 +413,11 @@ int modbus_read_input_regs(const int iface,
 	return err;
 }
 
-int modbus_write_coil(const int iface,
+int modbus_write_coil(struct modbus_context *ctx,
 		      const uint8_t unit_id,
 		      const uint16_t coil_addr,
 		      const bool coil_state)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 	uint16_t coil_val;
 
@@ -449,12 +443,11 @@ int modbus_write_coil(const int iface,
 	return err;
 }
 
-int modbus_write_holding_reg(const int iface,
+int modbus_write_holding_reg(struct modbus_context *ctx,
 			     const uint8_t unit_id,
 			     const uint16_t start_addr,
 			     const uint16_t reg_val)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	int err;
 
 	if (ctx == NULL) {
@@ -473,13 +466,13 @@ int modbus_write_holding_reg(const int iface,
 	return err;
 }
 
-int modbus_request_diagnostic(const int iface,
+int modbus_request_diagnostic(struct modbus_context *ctx,
 			      const uint8_t unit_id,
 			      const uint16_t sfunc,
 			      const uint16_t data,
 			      uint16_t *const data_out)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
+	
 	int err;
 
 	if (ctx == NULL) {
@@ -498,13 +491,12 @@ int modbus_request_diagnostic(const int iface,
 	return err;
 }
 
-int modbus_write_coils(const int iface,
+int modbus_write_coils(struct modbus_context *ctx,
 		       const uint8_t unit_id,
 		       const uint16_t start_addr,
 		       uint8_t *const coil_tbl,
 		       const uint16_t num_coils)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
 	size_t length = 0;
 	uint8_t *data_ptr;
 	size_t num_bytes;
@@ -542,13 +534,13 @@ int modbus_write_coils(const int iface,
 	return err;
 }
 
-int modbus_write_holding_regs(const int iface,
+int modbus_write_holding_regs(struct modbus_context *ctx,
 			      const uint8_t unit_id,
 			      const uint16_t start_addr,
 			      uint16_t *const reg_buf,
 			      const uint16_t num_regs)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
+	
 	size_t length = 0;
 	uint8_t *data_ptr;
 	size_t num_bytes;
@@ -590,13 +582,13 @@ int modbus_write_holding_regs(const int iface,
 }
 
 #ifdef CONFIG_MODBUS_FP_EXTENSIONS
-int modbus_write_holding_regs_fp(const int iface,
+int modbus_write_holding_regs_fp(struct modbus_context *ctx,
 				 const uint8_t unit_id,
 				 const uint16_t start_addr,
 				 float *const reg_buf,
 				 const uint16_t num_regs)
 {
-	struct modbus_context *ctx = modbus_get_context(iface);
+	
 	size_t length = 0;
 	uint8_t *data_ptr;
 	size_t num_bytes;

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -12,58 +12,9 @@ LOG_MODULE_REGISTER(modbus, CONFIG_MODBUS_LOG_LEVEL);
 #include <string.h>
 #include <sys/byteorder.h>
 #include <modbus_internal.h>
+#include <device.h>
 
 #define DT_DRV_COMPAT zephyr_modbus_serial
-
-#define MB_RTU_DEFINE_GPIO_CFG(inst, prop)				\
-	static struct gpio_dt_spec prop##_cfg_##inst = {		\
-		.port = DEVICE_DT_GET(DT_INST_PHANDLE(inst, prop)),	\
-		.pin = DT_INST_GPIO_PIN(inst, prop),			\
-		.dt_flags = DT_INST_GPIO_FLAGS(inst,  prop),		\
-	};
-
-#define MB_RTU_DEFINE_GPIO_CFGS(inst)					\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, de_gpios),		\
-		    (MB_RTU_DEFINE_GPIO_CFG(inst, de_gpios)), ())	\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, re_gpios),		\
-		    (MB_RTU_DEFINE_GPIO_CFG(inst, re_gpios)), ())
-
-DT_INST_FOREACH_STATUS_OKAY(MB_RTU_DEFINE_GPIO_CFGS)
-
-#define MB_RTU_ASSIGN_GPIO_CFG(inst, prop)			\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, prop),		\
-		    (&prop##_cfg_##inst), (NULL))
-
-#define MODBUS_DT_GET_SERIAL_DEV(inst) {			\
-		.dev_name = DT_INST_BUS_LABEL(inst),		\
-		.de = MB_RTU_ASSIGN_GPIO_CFG(inst, de_gpios),	\
-		.re = MB_RTU_ASSIGN_GPIO_CFG(inst, re_gpios),	\
-	},
-
-#ifdef CONFIG_MODBUS_SERIAL
-static struct modbus_serial_config modbus_serial_cfg[] = {
-	DT_INST_FOREACH_STATUS_OKAY(MODBUS_DT_GET_SERIAL_DEV)
-};
-#endif
-
-#define MODBUS_DT_GET_DEV(inst) {				\
-		.iface_name = DT_INST_LABEL(inst),		\
-		.cfg = &modbus_serial_cfg[inst],		\
-	},
-
-#define DEFINE_MODBUS_RAW_ADU(x, _) {				\
-		.iface_name = "RAW_"#x,				\
-		.raw_tx_cb = NULL,				\
-		.mode = MODBUS_MODE_RAW,			\
-	},
-
-
-static struct modbus_context mb_ctx_tbl[] = {
-	DT_INST_FOREACH_STATUS_OKAY(MODBUS_DT_GET_DEV)
-#ifdef CONFIG_MODBUS_RAW_ADU
-	UTIL_LISTIFY(CONFIG_MODBUS_NUMOF_RAW_ADU, DEFINE_MODBUS_RAW_ADU, _)
-#endif
-};
 
 static void modbus_rx_handler(struct k_work *item)
 {
@@ -93,9 +44,12 @@ static void modbus_rx_handler(struct k_work *item)
 		return;
 	}
 
+	LOG_WRN("RX handler");
+
 	if (ctx->client == true) {
 		k_sem_give(&ctx->client_wait_sem);
 	} else if (IS_ENABLED(CONFIG_MODBUS_SERVER)) {
+		LOG_WRN("RX handler call");
 		bool respond = modbus_server_handler(ctx);
 
 		if (respond) {
@@ -151,73 +105,21 @@ int modbus_tx_wait_rx_adu(struct modbus_context *ctx)
 	return ctx->rx_adu_err;
 }
 
-struct modbus_context *modbus_get_context(const uint8_t iface)
+static int modbus_init_iface(struct modbus_context *ctx)
 {
-	struct modbus_context *ctx;
-
-	if (iface >= ARRAY_SIZE(mb_ctx_tbl)) {
-		LOG_ERR("Interface %u not available", iface);
-		return NULL;
-	}
-
-	ctx = &mb_ctx_tbl[iface];
-
-	if (!atomic_test_bit(&ctx->state, MODBUS_STATE_CONFIGURED)) {
-		LOG_ERR("Interface not configured");
-		return NULL;
-	}
-
-	return ctx;
-}
-
-int modbus_iface_get_by_ctx(const struct modbus_context *ctx)
-{
-	for (int i = 0; i < ARRAY_SIZE(mb_ctx_tbl); i++) {
-		if (&mb_ctx_tbl[i] == ctx) {
-			return i;
-		}
-	}
-
-	return -ENODEV;
-}
-
-int modbus_iface_get_by_name(const char *iface_name)
-{
-	for (int i = 0; i < ARRAY_SIZE(mb_ctx_tbl); i++) {
-		if (strcmp(iface_name, mb_ctx_tbl[i].iface_name) == 0) {
-			return i;
-		}
-	}
-
-	return -ENODEV;
-}
-
-static struct modbus_context *modbus_init_iface(const uint8_t iface)
-{
-	struct modbus_context *ctx;
-
-	if (iface >= ARRAY_SIZE(mb_ctx_tbl)) {
-		LOG_ERR("Interface %u not available", iface);
-		return NULL;
-	}
-
-	ctx = &mb_ctx_tbl[iface];
-
 	if (atomic_test_and_set_bit(&ctx->state, MODBUS_STATE_CONFIGURED)) {
 		LOG_ERR("Interface allready used");
-		return NULL;
+		return -EINVAL;
 	}
 
 	k_mutex_init(&ctx->iface_lock);
 	k_sem_init(&ctx->client_wait_sem, 0, 1);
 	k_work_init(&ctx->server_work, modbus_rx_handler);
-
-	return ctx;
+	return 0;
 }
 
-int modbus_init_server(const int iface, struct modbus_iface_param param)
+int modbus_init_server(struct modbus_context *ctx, struct modbus_iface_param param)
 {
-	struct modbus_context *ctx = NULL;
 	int rc = 0;
 
 	if (!IS_ENABLED(CONFIG_MODBUS_SERVER)) {
@@ -232,11 +134,14 @@ int modbus_init_server(const int iface, struct modbus_iface_param param)
 		goto init_server_error;
 	}
 
-	ctx = modbus_init_iface(iface);
-	if (ctx == NULL) {
+	rc = modbus_init_iface(ctx);
+	if (rc != 0) {
+		LOG_ERR("Modbus server failed to set iface");
 		rc = -EINVAL;
 		goto init_server_error;
 	}
+
+	LOG_DBG("After iface");
 
 	switch (param.mode) {
 	case MODBUS_MODE_RTU:
@@ -269,7 +174,7 @@ int modbus_init_server(const int iface, struct modbus_iface_param param)
 		modbus_reset_stats(ctx);
 	}
 
-	LOG_DBG("Modbus interface %s initialized", ctx->iface_name);
+	LOG_DBG("Modbus interface %d initialized", ctx->unit_id);
 
 	return 0;
 
@@ -281,9 +186,8 @@ init_server_error:
 	return rc;
 }
 
-int modbus_init_client(const int iface, struct modbus_iface_param param)
+int modbus_init_client(struct modbus_context *ctx, struct modbus_iface_param param)
 {
-	struct modbus_context *ctx = NULL;
 	int rc = 0;
 
 	if (!IS_ENABLED(CONFIG_MODBUS_CLIENT)) {
@@ -292,8 +196,8 @@ int modbus_init_client(const int iface, struct modbus_iface_param param)
 		goto init_client_error;
 	}
 
-	ctx = modbus_init_iface(iface);
-	if (ctx == NULL) {
+	rc = modbus_init_iface(ctx);
+	if (rc != 0) {
 		rc = -EINVAL;
 		goto init_client_error;
 	}
@@ -337,13 +241,10 @@ init_client_error:
 	return rc;
 }
 
-int modbus_disable(const uint8_t iface)
+int modbus_disable(struct modbus_context *ctx)
 {
-	struct modbus_context *ctx;
-
-	ctx = modbus_get_context(iface);
 	if (ctx == NULL) {
-		LOG_ERR("Interface %u not initialized", iface);
+		LOG_ERR("Interface not initialized");
 		return -EINVAL;
 	}
 
@@ -366,7 +267,7 @@ int modbus_disable(const uint8_t iface)
 	ctx->mbs_user_cb = NULL;
 	atomic_clear_bit(&ctx->state, MODBUS_STATE_CONFIGURED);
 
-	LOG_INF("Modbus interface %u disabled", iface);
+	LOG_INF("Modbus interface disabled");
 
 	return 0;
 }

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -44,12 +44,9 @@ static void modbus_rx_handler(struct k_work *item)
 		return;
 	}
 
-	LOG_WRN("RX handler");
-
 	if (ctx->client == true) {
 		k_sem_give(&ctx->client_wait_sem);
 	} else if (IS_ENABLED(CONFIG_MODBUS_SERVER)) {
-		LOG_WRN("RX handler call");
 		bool respond = modbus_server_handler(ctx);
 
 		if (respond) {
@@ -140,8 +137,6 @@ int modbus_init_server(struct modbus_context *ctx, struct modbus_iface_param par
 		rc = -EINVAL;
 		goto init_server_error;
 	}
-
-	LOG_DBG("After iface");
 
 	switch (param.mode) {
 	case MODBUS_MODE_RTU:

--- a/subsys/modbus/modbus_internal.h
+++ b/subsys/modbus/modbus_internal.h
@@ -80,84 +80,8 @@
 /* Modbus ADU constants */
 #define MODBUS_ADU_PROTO_ID			0x0000
 
-struct modbus_serial_config {
-	/* UART device name */
-	const char *dev_name;
-	/* UART device */
-	const struct device *dev;
-	/* RTU timeout (maximum inter-frame delay) */
-	uint32_t rtu_timeout;
-	/* Pointer to current position in buffer */
-	uint8_t *uart_buf_ptr;
-	/* Pointer to driver enable (DE) pin config */
-	struct gpio_dt_spec *de;
-	/* Pointer to receiver enable (nRE) pin config */
-	struct gpio_dt_spec *re;
-	/* RTU timer to detect frame end point */
-	struct k_timer rtu_timer;
-	/* Number of bytes received or to send */
-	uint16_t uart_buf_ctr;
-	/* Storage of received characters or characters to send */
-	uint8_t uart_buf[CONFIG_MODBUS_BUFFER_SIZE];
-};
 
 #define MODBUS_STATE_CONFIGURED		0
-
-struct modbus_context {
-	/* Interface name */
-	const char *iface_name;
-	union {
-		/* Serial line configuration */
-		struct modbus_serial_config *cfg;
-		/* RAW TX callback */
-		modbus_raw_cb_t raw_tx_cb;
-	};
-	/* MODBUS mode */
-	enum modbus_mode mode;
-	/* True if interface is configured as client */
-	bool client;
-	/* Amount of time client is willing to wait for response from server */
-	uint32_t rxwait_to;
-	/* Pointer to user server callbacks */
-	struct modbus_user_callbacks *mbs_user_cb;
-	/* Interface state */
-	atomic_t state;
-
-	/* Client's mutually exclusive access */
-	struct k_mutex iface_lock;
-	/* Wait for response semaphore */
-	struct k_sem client_wait_sem;
-	/* Server work item */
-	struct k_work server_work;
-	/* Received frame */
-	struct modbus_adu rx_adu;
-	/* Frame to transmit */
-	struct modbus_adu tx_adu;
-
-	/* Records error from frame reception, e.g. CRC error */
-	int rx_adu_err;
-
-#ifdef CONFIG_MODBUS_FC08_DIAGNOSTIC
-	uint16_t mbs_msg_ctr;
-	uint16_t mbs_crc_err_ctr;
-	uint16_t mbs_except_ctr;
-	uint16_t mbs_server_msg_ctr;
-	uint16_t mbs_noresp_ctr;
-#endif
-	/* Unit ID */
-	uint8_t unit_id;
-
-};
-
-/**
- * @brief Get Modbus interface context.
- *
- * @param ctx        Modbus interface context
- *
- * @retval           Pointer to interface context or NULL
- *                   if interface not available or not configured;
- */
-struct modbus_context *modbus_get_context(const uint8_t iface);
 
 /**
  * @brief Get Modbus interface index.

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -321,16 +321,11 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 
 	reg_addr = sys_get_be16(&ctx->rx_adu.data[0]);
 	reg_qty = sys_get_be16(&ctx->rx_adu.data[2]);
-	LOG_WRN("READ: addr: %x num: %d", reg_addr, reg_qty);
-	LOG_WRN("READ: cbs: %p holding: %p", ctx->mbs_user_cb, ctx->mbs_user_cb->holding_reg_rd);
-	LOG_WRN("ENABLED STATE: %d", IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS));
 
 	if ((reg_addr < MODBUS_FP_EXTENSIONS_ADDR) ||
 	    !IS_ENABLED(CONFIG_MODBUS_FP_EXTENSIONS)) {
-			LOG_WRN("non ext");
 		/* Read integer register */
 		if (ctx->mbs_user_cb->holding_reg_rd == NULL) {
-			LOG_WRN("Why????");
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
@@ -344,7 +339,6 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 		/* Get number of bytes needed for response. */
 		num_bytes = (uint8_t)(reg_qty * sizeof(uint16_t));
 	} else {
-		LOG_WRN("ext");
 		/* Read floating-point register */
 		if (ctx->mbs_user_cb->holding_reg_rd_fp == NULL) {
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
@@ -938,7 +932,6 @@ bool modbus_server_handler(struct modbus_context *ctx)
 	uint8_t addr = ctx->rx_adu.unit_id;
 	uint8_t fc = ctx->rx_adu.fc;
 
-	LOG_DBG("Server RX handler %p", ctx);
 	update_msg_ctr(ctx);
 
 	if (ctx->rx_adu_err != 0) {
@@ -949,10 +942,8 @@ bool modbus_server_handler(struct modbus_context *ctx)
 
 		return false;
 	}
-	LOG_DBG("Server addr %d %d", addr, ctx->unit_id);
 
 	if (addr != 0 && addr != ctx->unit_id) {
-		LOG_DBG("Server addr %d != %d", addr, ctx->unit_id);
 		update_noresp_ctr(ctx);
 		return false;
 	}
@@ -964,8 +955,6 @@ bool modbus_server_handler(struct modbus_context *ctx)
 	ctx->tx_adu.fc = fc;
 
 	update_server_msg_ctr(ctx);
-
-	LOG_DBG("Server FC handler %d", fc);
 
 	switch (fc) {
 	case MODBUS_FC01_COIL_RD:


### PR DESCRIPTION
 To get rid of the arbitrairy iface numbers which are hard to deal with in the devicetree